### PR TITLE
Fix path for invoices.retrieveUpcoming

### DIFF
--- a/lib/resources/invoices.cfc
+++ b/lib/resources/invoices.cfc
@@ -39,7 +39,10 @@ component extends="abstract.apiResource" {
                         amount: 'currency'
                     }
                 },
-                path: '/invoices/upcoming'
+                path: '/invoices/upcoming',
+                positionalArgs: [
+                    'customer'
+                ]
             },
             'update': {
                 arguments: {

--- a/lib/resources/invoices.cfc
+++ b/lib/resources/invoices.cfc
@@ -33,11 +33,13 @@ component extends="abstract.apiResource" {
             },
             'retrieveUpcoming': {
                 arguments: {
+                    subscription_proration_date: 'timestamp',
+                    subscription_trial_end: 'timestamp',
                     invoice_items: {
                         amount: 'currency'
                     }
                 },
-                path: '/invoices/{invoice_id}/upcoming'
+                path: '/invoices/upcoming'
             },
             'update': {
                 arguments: {

--- a/reference.md
+++ b/reference.md
@@ -149,7 +149,7 @@ stripe.invoices.list();
 stripe.invoices.pay(invoice_id);
 stripe.invoices.retrieve(invoice_id);
 stripe.invoices.retrieveLines(invoice_id);
-stripe.invoices.retrieveUpcoming(invoice_id);
+stripe.invoices.retrieveUpcoming();
 stripe.invoices.update(invoice_id);
 ```
 

--- a/reference.md
+++ b/reference.md
@@ -149,7 +149,7 @@ stripe.invoices.list();
 stripe.invoices.pay(invoice_id);
 stripe.invoices.retrieve(invoice_id);
 stripe.invoices.retrieveLines(invoice_id);
-stripe.invoices.retrieveUpcoming();
+stripe.invoices.retrieveUpcoming(customer);
 stripe.invoices.update(invoice_id);
 ```
 


### PR DESCRIPTION
Does not accept invoice_id argument or need invoice_id in path. I also added a couple additional argument types for subscription_proration_date and subscription_trial_ends.

https://stripe.com/docs/api/node#upcoming_invoice