### PR TITLE
Make billing_cycle_anchor timestamp on create() and update()

### DIFF
--- a/lib/resources/subscriptions.cfc
+++ b/lib/resources/subscriptions.cfc
@@ -4,7 +4,8 @@ component extends="abstract.apiResource" {
         methods: {
             'create': {
                 arguments: {
-                    trial_end: 'timestamp'
+                    trial_end: 'timestamp',
+                    billing_cycle_anchor: 'timestamp'
                 },
                 httpMethod: 'post',
                 path: '/subscriptions'
@@ -29,7 +30,8 @@ component extends="abstract.apiResource" {
             'update': {
                 arguments: {
                     proration_date: 'timestamp',
-                    trial_end: 'timestamp'
+                    trial_end: 'timestamp',
+                    billing_cycle_anchor: 'timestamp'
                 },
                 httpMethod: 'post',
                 path: '/subscriptions/{subscription_id}'


### PR DESCRIPTION
on subscription.create() and subscription.update()

previous PR only converted this key on incoming payloads. this also converts for POSTs