### PR TITLE
Credit note & credit note line item updates

### DIFF
--- a/lib/resources/creditNotes.cfc
+++ b/lib/resources/creditNotes.cfc
@@ -6,7 +6,13 @@ component {
                 arguments: {
                     amount: 'currency',
                     credit_amount: 'currency',
-                    refund_amount: 'currency'
+                    refund_amount: 'currency',
+                    out_of_band_amount: 'currency',
+                    lines : {
+                        amount : "currency",
+                        unit_amount : "currency",
+                        unit_amount_decimal : "currency"
+                    }
                 },
                 httpMethod: 'post',
                 path: '/credit_notes'
@@ -23,7 +29,8 @@ component {
                     credit_amount: 'currency',
                     lines: {
                         amount: 'currency',
-                        unit_amount: 'currency'
+                        unit_amount: 'currency',
+                        unit_amount_decimal: 'currency'
                     },
                     out_of_band_amount: 'currency',
                     refund_amount: 'currency'
@@ -36,7 +43,8 @@ component {
                     credit_amount: 'currency',
                     lines: {
                         amount: 'currency',
-                        unit_amount: 'currency'
+                        unit_amount: 'currency',
+                        unit_amount_decimal : "currency"
                     },
                     out_of_band_amount: 'currency',
                     refund_amount: 'currency'

--- a/metadata/credit_note.json
+++ b/metadata/credit_note.json
@@ -1,4 +1,7 @@
 {
     "amount": "currency",
+    "credit_amount" : "currency",
+    "out_of_band_amount" : "currency",
+    "refund_amount" : "currency",
     "created": "datetime"
 }

--- a/metadata/credit_note_line_item.json
+++ b/metadata/credit_note_line_item.json
@@ -1,0 +1,11 @@
+{
+    "amount" : "currency",
+    "unit_amount" : "currency",
+    "unit_amount_decimal" : "currency",
+    "discount_amounts" : {
+        "amount" : "currency"
+    },
+    "tax_amounts" : {
+        "amount" : "currency"
+    }
+}


### PR DESCRIPTION
Add  credit_note_line_item.json metadata object
Add credit_amount, out_of_band_amount, and refund_amount to credit_note metadata object
Add additional currency fields to creditNotes.cfc
Relates to https://github.com/jcberquist/stripe-cfml/issues/27