### PR TITLE
Add subtotal and total to credit_note

### DIFF
--- a/metadata/credit_note.json
+++ b/metadata/credit_note.json
@@ -3,5 +3,7 @@
     "created": "datetime",
     "credit_amount": "currency",
     "out_of_band_amount": "currency",
-    "refund_amount": "currency"
+    "refund_amount": "currency",
+    "subtotal" : "currency",
+    "total" : "currency"
 }


### PR DESCRIPTION
Added two fields I missed before in the Stripe credit note response object.