### PR TITLE
Throw custom exception when Content-Type is missing (#47)

### DIFF
--- a/stripe.cfc
+++ b/stripe.cfc
@@ -119,9 +119,17 @@ component {
             );
         }
 
-        if ( response.headers[ 'Content-Type' ] == 'application/json' ) {
-            response.content = deserializeJSON( response.content );
-            parsers.response.parse( response.content );
+        if ( structKeyExists( response.headers, 'Content-Type' ) ) {
+            if ( response.headers[ 'Content-Type' ] == 'application/json' ) {
+                response.content = deserializeJSON( response.content );
+                parsers.response.parse( response.content );
+            }
+        } else if ( int( response.status ) >= 200 && int( response.status ) < 300 ) {
+            throw(
+                type = 'StripeResponseException',
+                message = 'Content-Type is missing from the response headers',
+                extendedInfo = serializeJSON( response )
+            );
         }
 
         return response;


### PR DESCRIPTION
Same as the check for Request-Id, this checks response.headers for existence of 'Content-Type' before processing application/json. If Content-Type doesn't exist, throw error if response.status is greater than 200 and less than 300.