### PR TITLE
Don't implicitly set `default_currency` in account update

### DIFF
--- a/lib/resources/accounts.cfc
+++ b/lib/resources/accounts.cfc
@@ -357,7 +357,6 @@ component {
                             date: 'timestamp'
                         }
                     },
-                    default_currency: 'iso_currency_code',
                     settings: {
                         card_issuing: {
                             tos_acceptance: {


### PR DESCRIPTION
Don't implicitly set `default_currency` in account update. Doing so causes the account to change its currency if it's different from what the config has set, unless `default_currency` is always supplied by the caller.

This causes confusion when attempting to update something like the account's `business_name`. If `default_currency` isn't passed, then the account's default currency may change if it doesn't already match the config's value.