### PR TITLE
If payment intent status is requires_confirmation then stripe not all…

### DIFF
--- a/lib/resources/paymentIntents.cfc
+++ b/lib/resources/paymentIntents.cfc
@@ -143,7 +143,6 @@ component {
                 arguments: {
                     amount: 'currency',
                     application_fee_amount: 'currency',
-                    currency: 'iso_currency_code',
                     payment_method_options: {
                         card: {
                             installments: {


### PR DESCRIPTION
If payment intent status is requires_confirmation, then Stripe is not allowed to change currency.